### PR TITLE
Use default Composer type for Drupal modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,7 @@
 {
     "name": "su-sws/nobots",
     "description": "This module blocks (well-behaved) search engine robots from crawling, indexing, or archiving your site by setting a \"X-Robots-Tag: noindex,nofollow,noarchive\" HTTP header.",
-    "type": "drupal-custom-module",
+    "type": "drupal-module",
     "license": "GPL-2.0+",
-    "minimum-stability": "dev",
-    "require": {
-        "composer/installers": "~1.0"
-    }
+    "minimum-stability": "dev"
 }


### PR DESCRIPTION
Modules on Drupal.org uses the `drupal-module` Composer type. This change
ensures that this project does the same.

Consequently there is no need have a dependency to `composer/installers`
either.

If someone wants to treat this module - or all modules from a specific
vendor differently they then can add and use `composer/installers` to do
so e.g.

```json
{
    "extra": {
        "installer-paths": {
            "web/modules/custom/{$name}/": ["vendor:su-sws"]
        }
    }
}
```