### PR TITLE
Allow/prevent bot crawling based on settings.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ Configuration
 Enable the module to block search engine robots.
 Disable the module to let them crawl your site.
 
+Advanced Configuration
+---
+You can set the `nobots` variable to **FALSE** to leave the module enabled, yet still allow robots to crawl your site.
+
+An example use-case would be to set `$settings['nobots'] = FALSE;` in settings.php for the production environment, and `TRUE` for all other environments.
+
 Troubleshooting
 ---
 

--- a/src/EventSubscriber/FinishResponseSubscriber.php
+++ b/src/EventSubscriber/FinishResponseSubscriber.php
@@ -9,6 +9,8 @@ use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 
 namespace Drupal\nobots\EventSubscriber;
 
+use Drupal\Core\Site\Settings;
+
 /**
  * Response subscriber to handle finished responses.
  */
@@ -21,9 +23,10 @@ class FinishResponseSubscriber extends \Drupal\Core\EventSubscriber\FinishRespon
    *   The event to process.
    */
   public function onRespond(\Symfony\Component\HttpKernel\Event\FilterResponseEvent $event) {
-    $request = $event->getRequest();
-    $response = $event->getResponse();
-    $response->headers->set('X-Robots-Tag', 'noindex,nofollow,noarchive', FALSE);
+    if (Settings::get('nobots', TRUE)) {
+      $response = $event->getResponse();
+      $response->headers->set('X-Robots-Tag', 'noindex,nofollow,noarchive', FALSE);
+    }
   }
 
 }


### PR DESCRIPTION
This allows you to keep the module enabled on all sites but control
if crawling should be allowed based on `settings.php`.

This brings the Drupal 8 version up to feature parity with the Drupal 7
version.

Update `README` accordingly. The only difference is that the configuration
goes in `$settings` - not in `$conf`.

Note that the `use` statement must be below the `namespace` declaration - 
not above. It would be good to have this fixed in the rest of the module
but I left that for another PR.