### PR TITLE
Cleaned up event subscriber

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 #[No Bots](https://github.com/SU-SWS/nobots)
 ##### Version: 8.x-1.0-dev
 
-Maintainers: [jbickar](https://github.com/jbickar), [sherakama](https://github.com/sherakama)
+Maintainers: [jbickar](https://github.com/jbickar), [sherakama](https://github.com/sherakama), [pookmish](https://github.com/pookmish)
 [Changelog.txt](CHANGELOG.txt)
 
 

--- a/nobots.services.yml
+++ b/nobots.services.yml
@@ -1,6 +1,5 @@
 services:
-  finish_response_subscriber:
+  nobots.finish_response_subscriber:
     class: Drupal\nobots\EventSubscriber\FinishResponseSubscriber
     tags:
       - { name: event_subscriber }
-    arguments: ['@language_manager', '@config.factory', '@page_cache_request_policy', '@page_cache_response_policy', '@cache_contexts_manager', '%http.response.debug_cacheability_headers%']

--- a/src/EventSubscriber/FinishResponseSubscriber.php
+++ b/src/EventSubscriber/FinishResponseSubscriber.php
@@ -1,18 +1,23 @@
 <?php
-/**
- * Event Subscriber.
- *
- */
-
-use Drupal\Core\EventSubscriber\FinishResponseSubscriber;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 
 namespace Drupal\nobots\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
  * Response subscriber to handle finished responses.
  */
-class FinishResponseSubscriber extends \Drupal\Core\EventSubscriber\FinishResponseSubscriber {
+class FinishResponseSubscriber  implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[KernelEvents::RESPONSE][] = ['onRespond'];
+    return $events;
+  }
 
   /**
    * Sets extra headers on successful responses.
@@ -20,7 +25,7 @@ class FinishResponseSubscriber extends \Drupal\Core\EventSubscriber\FinishRespon
    * @param \Symfony\Component\HttpKernel\Event\FilterResponseEvent $event
    *   The event to process.
    */
-  public function onRespond(\Symfony\Component\HttpKernel\Event\FilterResponseEvent $event) {
+  public function onRespond(FilterResponseEvent $event) {
     $request = $event->getRequest();
     $response = $event->getResponse();
     $response->headers->set('X-Robots-Tag', 'noindex,nofollow,noarchive', FALSE);

--- a/src/EventSubscriber/FinishResponseSubscriber.php
+++ b/src/EventSubscriber/FinishResponseSubscriber.php
@@ -26,11 +26,10 @@ class FinishResponseSubscriber implements EventSubscriberInterface {
    * @param \Symfony\Component\HttpKernel\Event\FilterResponseEvent $event
    *   The event to process.
    */
-
   public function onRespond(FilterResponseEvent $event) {
     if (Settings::get('nobots', TRUE)) {
       $response = $event->getResponse();
-      $response->headers->set('X-Robots-Tag', 'noindex,nofollow,noarchive', FALSE); 
+      $response->headers->set('X-Robots-Tag', 'noindex,nofollow,noarchive', FALSE);
     }
   }
 

--- a/src/EventSubscriber/FinishResponseSubscriber.php
+++ b/src/EventSubscriber/FinishResponseSubscriber.php
@@ -28,8 +28,10 @@ class FinishResponseSubscriber implements EventSubscriberInterface {
    */
 
   public function onRespond(FilterResponseEvent $event) {
-    $response = $event->getResponse();
-    $response->headers->set('X-Robots-Tag', 'noindex,nofollow,noarchive', FALSE); 
+    if (Settings::get('nobots', TRUE)) {
+      $response = $event->getResponse();
+      $response->headers->set('X-Robots-Tag', 'noindex,nofollow,noarchive', FALSE); 
+    }
   }
 
 }

--- a/src/EventSubscriber/FinishResponseSubscriber.php
+++ b/src/EventSubscriber/FinishResponseSubscriber.php
@@ -9,7 +9,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
 /**
  * Response subscriber to handle finished responses.
  */
-class FinishResponseSubscriber  implements EventSubscriberInterface {
+class FinishResponseSubscriber implements EventSubscriberInterface {
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Cleaned up event subscriber. Theres no need to extend an existing event subscriber for the things this is doing.

This should be able to be merged independently of https://github.com/SU-SWS/nobots/pull/4